### PR TITLE
[FEAT] 길찾기 - 저장된 장소 화면 구현

### DIFF
--- a/lib/common/enum/place_category.dart
+++ b/lib/common/enum/place_category.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+enum PlaceCategory { home, work, school, restaurant, mart, hospital, etc }
+
+extension PlaceCategoryExtension on PlaceCategory {
+  // 카테고리 이름
+  String get label {
+    switch (this) {
+      case PlaceCategory.home:
+        return '집';
+      case PlaceCategory.work:
+        return '회사';
+      case PlaceCategory.school:
+        return '학교';
+      case PlaceCategory.restaurant:
+        return '식당/카페';
+      case PlaceCategory.mart:
+        return '마트/편의점';
+      case PlaceCategory.hospital:
+        return '병원/약국';
+      case PlaceCategory.etc:
+        return '기타';
+    }
+  }
+
+  // 아이콘
+  IconData get icon {
+    switch (this) {
+      case PlaceCategory.home:
+        return Icons.home;
+      case PlaceCategory.work:
+        return Icons.work_rounded;
+      case PlaceCategory.school:
+        return Icons.school_rounded;
+      case PlaceCategory.restaurant:
+        return Icons.restaurant;
+      case PlaceCategory.mart:
+        return Icons.local_grocery_store_outlined;
+      case PlaceCategory.hospital:
+        return Icons.local_hospital_outlined;
+      case PlaceCategory.etc:
+        return Icons.more_outlined;
+    }
+  }
+}

--- a/lib/data/saved_place_dummy.dart
+++ b/lib/data/saved_place_dummy.dart
@@ -1,0 +1,35 @@
+import 'package:safepath/models/saved_place.dart';
+import 'package:safepath/common/enum/place_category.dart';
+
+final savedPlaces = [
+  SavedPlace(
+    label: '집',
+    location: '서울특별시 성북구 솔샘로8길',
+    category: PlaceCategory.home,
+  ),
+  SavedPlace(
+    label: '학교',
+    location: '서울특별시 성북구 정릉로 77',
+    category: PlaceCategory.school,
+  ),
+  SavedPlace(
+    label: '회사',
+    location: '서울특별시 성북구 보국문로 10',
+    category: PlaceCategory.work,
+  ),
+  SavedPlace(
+    label: '병원',
+    location: '서울특별시 성북구 보국문로 92',
+    category: PlaceCategory.hospital,
+  ),
+  SavedPlace(
+    label: '카페',
+    location: '서울특별시 성북구 아리랑로 2',
+    category: PlaceCategory.restaurant,
+  ),
+  SavedPlace(
+    label: '마트',
+    location: '서울특별시 성북구 정릉로 5',
+    category: PlaceCategory.mart,
+  ),
+];

--- a/lib/features/navigation/edit_button.dart
+++ b/lib/features/navigation/edit_button.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+import 'package:safepath/routes/app_router.dart';
+
+class EditButton extends StatelessWidget {
+  const EditButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(10),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(10),
+        onTap: () => Navigator.pushNamed(context, AppRouter.savedplace),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 5),
+          decoration: BoxDecoration(
+            color: ColorCollection.point.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(color: ColorCollection.point, width: 1),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(5),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Icon(Icons.edit, size: 18, color: ColorCollection.point),
+                const SizedBox(width: 5),
+                Text(
+                  '편집',
+                  style: AppTextStyles.labelRegular.copyWith(
+                    color: ColorCollection.point,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/navigation/navigation_screen.dart
+++ b/lib/features/navigation/navigation_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:safepath/common/enum/place_category.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/widgets/title_bar_widget.dart';
+import 'package:safepath/features/navigation/edit_button.dart';
+import 'package:safepath/features/navigation/saved_place_widget.dart';
 
 class NavigationScreen extends StatelessWidget {
   const NavigationScreen({super.key});
@@ -16,12 +19,36 @@ class NavigationScreen extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    '저장된 장소',
+                    style: AppTextStyles.title2.copyWith(
+                      color: ColorCollection.point,
+                      fontSize: 20,
+                    ),
+                  ),
+                  EditButton(),
+                ],
+              ),
+              const SizedBox(height: 25),
+              SavedPlaceWidget(
+                label: '집',
+                location: '서울특별시 성북구 솔샘로8길',
+                category: PlaceCategory.home,
+              ),
+              const SizedBox(height: 25),
               Text(
-                '길찾기',
+                '최근 장소',
                 style: AppTextStyles.title2.copyWith(
                   color: ColorCollection.point,
+                  fontSize: 20,
                 ),
               ),
+              const SizedBox(height: 25),
+              SavedPlaceWidget(label: '집', location: '서울특별시 성북구 솔샘로8길'),
             ],
           ),
         ),

--- a/lib/features/navigation/saved_place_screen.dart
+++ b/lib/features/navigation/saved_place_screen.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:safepath/common/widgets/action_button_widget.dart';
+import 'package:safepath/common/widgets/title_bar_widget.dart';
+import 'package:safepath/features/navigation/saved_place_widget.dart';
+import 'package:safepath/data/saved_place_dummy.dart';
+
+class SavedPlaceScreen extends StatefulWidget {
+  const SavedPlaceScreen({super.key});
+
+  @override
+  State<SavedPlaceScreen> createState() => _SavedPlaceScreenState();
+}
+
+class _SavedPlaceScreenState extends State<SavedPlaceScreen> {
+  bool isEditMode = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomTitleBar(title: '저장된 장소', showBackButton: true),
+      body: SafeArea(
+        bottom: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+          child: Column(
+            children: [
+              Expanded(
+                child: ListView.separated(
+                  padding: const EdgeInsets.only(bottom: 100),
+                  itemCount: savedPlaces.length,
+                  itemBuilder: (context, index) {
+                    final place = savedPlaces[index];
+
+                    return SavedPlaceWidget(
+                      label: place.label,
+                      location: place.location,
+                      category: place.category,
+                      isEditMode: isEditMode,
+                    );
+                  },
+                  separatorBuilder: (context, index) =>
+                      const SizedBox(height: 21),
+                ),
+              ),
+              SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 16, bottom: 24),
+                  child: ActionButton(
+                    label: isEditMode ? '저장하기' : '편집하기',
+                    icon: isEditMode
+                        ? Icons.check_circle_outline_rounded
+                        : Icons.edit,
+                    onTap: () {
+                      setState(() {
+                        isEditMode = !isEditMode;
+                      });
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/navigation/saved_place_widget.dart
+++ b/lib/features/navigation/saved_place_widget.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+import 'package:safepath/common/enum/place_category.dart';
+
+class SavedPlaceWidget extends StatelessWidget {
+  final String label; // 저장된 장소 이름
+  final String location; // 장소 주소
+  final PlaceCategory? category; // 카테고리 아이콘
+  final bool isEditMode; // 편집 모드 여부
+  final Color? labelTextColor; // default : point
+  final Color? locationTextColor; // default : point
+  final Color? iconBackgroundColor; // default : main
+  final Color? iconColor; // default = point
+  final VoidCallback? onTap;
+  final VoidCallback? onDelete; // 삭제 버튼 클릭
+
+  const SavedPlaceWidget({
+    super.key,
+    required this.label,
+    required this.location,
+    this.category,
+    this.isEditMode = false,
+    this.labelTextColor = ColorCollection.point,
+    this.locationTextColor = ColorCollection.point,
+    this.iconBackgroundColor = ColorCollection.main,
+    this.iconColor = ColorCollection.point,
+    this.onTap,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(10),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(10),
+        onTap: onTap,
+        child: Container(
+          decoration: BoxDecoration(
+            color: ColorCollection.point.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(color: ColorCollection.point, width: 2),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 16, 16, 16),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (category != null) ...[
+                  Container(
+                    width: 35,
+                    height: 35,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: ColorCollection.main,
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                    child: Icon(category?.icon, color: iconColor, size: 25),
+                  ),
+                  const SizedBox(width: 14),
+                ],
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        softWrap: true,
+                        style: AppTextStyles.bodyBold.copyWith(
+                          color: labelTextColor ?? ColorCollection.point,
+                        ),
+                      ),
+                      if (!isEditMode)
+                        Text(
+                          location,
+                          softWrap: true,
+                          style: AppTextStyles.labelRegular.copyWith(
+                            color: locationTextColor ?? ColorCollection.point,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 15),
+                if (isEditMode)
+                  GestureDetector(
+                    onTap: onDelete,
+                    child: Container(
+                      width: 50,
+                      height: 50,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: ColorCollection.red,
+                        borderRadius: BorderRadius.circular(10),
+                        border: Border.all(
+                          color: ColorCollection.point,
+                          width: 1,
+                        ),
+                      ),
+                      child: const Icon(
+                        Icons.delete,
+                        color: ColorCollection.point,
+                        size: 35,
+                      ),
+                    ),
+                  )
+                else
+                  Icon(
+                    Icons.arrow_forward_ios_rounded,
+                    color: ColorCollection.main,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/models/saved_place.dart
+++ b/lib/models/saved_place.dart
@@ -1,0 +1,31 @@
+import 'package:safepath/common/enum/place_category.dart';
+
+/// 저장된 장소 데이터 처리
+class SavedPlace {
+  final String label; // 장소 이름
+  final String location; // 주소
+  final PlaceCategory category; // 카테고리
+
+  const SavedPlace({
+    required this.label,
+    required this.location,
+    required this.category,
+  });
+
+  /// JSON -> Model(SavedPlace 객체) 변환
+  factory SavedPlace.fromJSON(Map<String, dynamic> json) {
+    return SavedPlace(
+      label: json['label'],
+      location: json['location'],
+      category: PlaceCategory.values.firstWhere(
+        (e) => e.name == json['category'],
+        orElse: () => PlaceCategory.etc,
+      ),
+    );
+  }
+
+  /// Model → JSON 변환 (서버 전송용)
+  Map<String, dynamic> toJson() {
+    return {'label': label, 'location': location, 'category': category.name};
+  }
+}

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:safepath/features/detection/detection_screen.dart';
 import 'package:safepath/features/navigation/navigation_screen.dart';
+import 'package:safepath/features/navigation/saved_place_screen.dart';
 import 'package:safepath/features/settings/settings_screen.dart';
 import 'package:safepath/features/settings/userguide_screen.dart';
 import 'package:safepath/features/signin/signin_screen.dart';
@@ -38,6 +39,7 @@ class AppRouter {
   static const String settings = '/settings';
   static const String userguide = '/settings/userguide';
   static const String navigation = '/navigation';
+  static const String savedplace = '/navigation/savedplace';
   static const String detection = '/detection';
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -54,6 +56,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const DetectionScreen());
       case userguide:
         return MaterialPageRoute(builder: (_) => const UserGuideScreen());
+      case savedplace:
+        return MaterialPageRoute(builder: (_) => const SavedPlaceScreen());
       default:
         return MaterialPageRoute(
           builder: (_) =>


### PR DESCRIPTION
## 📎 Issue 번호
#5 

## 📄 작업 내용 요약
- 장소 카테고리 enum 정의
   home, school, work, hospital, restaurant, mart, etc
- 저장된 장소 위젯 구현 : 저장된 장소 위젯, 편집 버튼 위젯
- 저장된 장소 화면 라우터 추가
- 길찾기 화면 : 저장된 장소, 최근 장소 UI 구현
- 저장된 장소 더미 데이터 및 모델 구현
- 길찾기 저장된 장소 화면 구현 (삭제 버튼은 백엔드 연동시 구현 예정)
<img width=30% alt="screen" src="https://github.com/user-attachments/assets/2927cf7f-7495-4314-8c88-d6e79c7e7fc5" />
<img width=30% alt="screen2" src="https://github.com/user-attachments/assets/e9a3c9f6-f9b4-4c5a-b6e9-8dc88a2e14a9" />
<img width=30% alt="screen3" src="https://github.com/user-attachments/assets/5c19045f-3389-4bee-8f89-4611f5236322" />
