### PR TITLE
[FEAT] 실외 장애물 탐지 화면  UI 구현

### DIFF
--- a/lib/features/detection/detection_active_view.dart
+++ b/lib/features/detection/detection_active_view.dart
@@ -47,7 +47,7 @@ class DetectionActiveView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
+    return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -101,8 +101,8 @@ class DetectionActiveView extends StatelessWidget {
                 children: [
                   Text(
                     '$detectedCount',
-                    style: AppTextStyles.headline.copyWith(
-                      color: ColorCollection.point,
+                    style: AppTextStyles.title1.copyWith(
+                      color: ColorCollection.main,
                     ),
                   ),
                   const SizedBox(height: 4),
@@ -118,24 +118,29 @@ class DetectionActiveView extends StatelessWidget {
           ),
           const SizedBox(height: 24),
 
-          // 감지된 장애물 섹션
+          // 감지된 장애물 섹션 (이 영역만 스크롤)
           Text(
             '감지된 장애물',
             style: AppTextStyles.title2.copyWith(color: ColorCollection.point),
           ),
           const SizedBox(height: 16),
 
-          // TODO: 실제 탐지 결과로 교체
-          for (final o in _dummyObstacles) ...[
-            ObstacleCard(
-              name: o.name,
-              distance: o.distance,
-              position: o.position,
-              vibration: o.vibration,
-              proximity: o.proximity,
+          Expanded(
+            child: ListView.separated(
+              itemCount: _dummyObstacles.length, // TODO: 실제 탐지 결과로 교체
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (_, index) {
+                final o = _dummyObstacles[index];
+                return ObstacleCard(
+                  name: o.name,
+                  distance: o.distance,
+                  position: o.position,
+                  vibration: o.vibration,
+                  proximity: o.proximity,
+                );
+              },
             ),
-            const SizedBox(height: 12),
-          ],
+          ),
         ],
       ),
     );

--- a/lib/features/detection/detection_active_view.dart
+++ b/lib/features/detection/detection_active_view.dart
@@ -1,0 +1,244 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+import 'package:safepath/features/detection/detection_button_widget.dart';
+import 'package:safepath/features/detection/obstacle_card_widget.dart';
+
+// TODO: 실제 AI 탐지 결과 연결 시 더미 데이터 제거
+const _dummyObstacles = [
+  (
+    name: '자전거',
+    distance: '가까움',
+    position: '정면',
+    vibration: '강한 진동 (연이은 진동)',
+    proximity: ObstacleProximity.near,
+  ),
+  (
+    name: '전봇대',
+    distance: '중간',
+    position: '왼쪽',
+    vibration: '중간 진동 (2회)',
+    proximity: ObstacleProximity.mid,
+  ),
+  (
+    name: '가로수',
+    distance: '멂',
+    position: '오른쪽',
+    vibration: '약한 진동 (1회)',
+    proximity: ObstacleProximity.far,
+  ),
+];
+
+/// 탐지 진행 화면 (탐지 중)
+class DetectionActiveView extends StatelessWidget {
+  final VoidCallback onStop;
+
+  /// 탐지된 물체 총 수
+  final int detectedCount;
+
+  const DetectionActiveView({
+    super.key,
+    required this.onStop,
+    required this.detectedCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 탐지 중지 버튼
+          Center(
+            child: DetectionButton(isDetecting: true, onTap: onStop, size: 180),
+          ),
+          const SizedBox(height: 20),
+
+          // 실시간 감지 활성화 상태 표시
+          Semantics(
+            label: '실시간 감지 활성화 중',
+            excludeSemantics: true,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: const BoxDecoration(
+                    color: ColorCollection.green,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '실시간 감지 활성화',
+                  style: AppTextStyles.bodyBold.copyWith(
+                    color: ColorCollection.point,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // 탐지된 물체 수 박스
+          Semantics(
+            label: '탐지된 물체 $detectedCount개',
+            excludeSemantics: true,
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 20),
+              decoration: BoxDecoration(
+                color: ColorCollection.point.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: ColorCollection.main, width: 3),
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    '$detectedCount',
+                    style: AppTextStyles.headline.copyWith(
+                      color: ColorCollection.point,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '탐지된 물체',
+                    style: AppTextStyles.bodyRegular.copyWith(
+                      color: ColorCollection.point,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // 감지된 장애물 섹션
+          Text(
+            '감지된 장애물',
+            style: AppTextStyles.title2.copyWith(color: ColorCollection.point),
+          ),
+          const SizedBox(height: 16),
+
+          // TODO: 실제 탐지 결과로 교체
+          for (final o in _dummyObstacles) ...[
+            ObstacleCard(
+              name: o.name,
+              distance: o.distance,
+              position: o.position,
+              vibration: o.vibration,
+              proximity: o.proximity,
+            ),
+            const SizedBox(height: 12),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// 탐지 중 로딩 표시
+class _LoadingIndicator extends StatefulWidget {
+  @override
+  State<_LoadingIndicator> createState() => _LoadingIndicatorState();
+}
+
+class _LoadingIndicatorState extends State<_LoadingIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 4),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '주변을 탐지하고 있습니다.',
+      excludeSemantics: true,
+      child: Center(
+        child: Column(
+          children: [
+            const SizedBox(height: 16),
+            AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) => CustomPaint(
+                size: const Size(40, 40),
+                painter: _LoadingPainter(progress: _controller.value),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '주변을 탐지하고 있습니다.',
+              style: AppTextStyles.labelRegular.copyWith(
+                color: ColorCollection.point,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LoadingPainter extends CustomPainter {
+  final double progress;
+
+  _LoadingPainter({required this.progress});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    const strokeWidth = 5.0;
+    final radius = (size.width - strokeWidth) / 2;
+
+    const gapAngle = 60 * pi / 180;
+    const orangeSweep = 50 * pi / 180;
+
+    final orangeStart = 2 * pi * progress - pi / 2;
+
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      orangeStart + orangeSweep + gapAngle / 2,
+      2 * pi - orangeSweep - gapAngle,
+      false,
+      Paint()
+        ..color = ColorCollection.point
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth
+        ..strokeCap = StrokeCap.round,
+    );
+
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      orangeStart,
+      orangeSweep,
+      false,
+      Paint()
+        ..color = ColorCollection.main
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth
+        ..strokeCap = StrokeCap.round,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_LoadingPainter old) => old.progress != progress;
+}

--- a/lib/features/detection/detection_button_widget.dart
+++ b/lib/features/detection/detection_button_widget.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+
+/// 탐지 시작/중지 원형 버튼
+///
+/// 사용 예시:
+/// DetectionButton(isDetecting: false, onTap: () {})  // 주황 - 탐지 시작
+/// DetectionButton(isDetecting: true, onTap: () {})   // 빨강 - 탐지 중지
+class DetectionButton extends StatelessWidget {
+  /// true: 탐지 중 (빨강/중지), false: 대기 중 (주황/시작)
+  final bool isDetecting;
+  final VoidCallback onTap;
+
+  /// 버튼 지름 (기본값: 180)
+  final double size;
+
+  const DetectionButton({
+    super.key,
+    required this.isDetecting,
+    required this.onTap,
+    this.size = 180,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isDetecting ? ColorCollection.red : ColorCollection.main;
+    final icon = isDetecting ? Icons.stop : Icons.play_arrow;
+    final label = isDetecting ? '탐지 중지' : '탐지 시작';
+
+    // 내부 요소들을 버튼 크기에 비례하여 스케일
+    final innerCircleSize = size * 0.34;
+    final iconSize = size * 0.20;
+    final spacing = size * 0.06;
+
+    return Semantics(
+      button: true,
+      label: label,
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // 내부 원형 테두리 + 아이콘
+              Container(
+                width: innerCircleSize,
+                height: innerCircleSize,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: ColorCollection.point,
+                    width: 2.5,
+                  ),
+                ),
+                child: Icon(icon, color: ColorCollection.point, size: iconSize),
+              ),
+              SizedBox(height: spacing),
+              Text(
+                label,
+                style: (isDetecting
+                        ? AppTextStyles.headline.copyWith(fontSize: 23)
+                        : AppTextStyles.headline)
+                    .copyWith(color: ColorCollection.point),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/detection/detection_idle_view.dart
+++ b/lib/features/detection/detection_idle_view.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+import 'package:safepath/features/detection/detection_button_widget.dart';
+
+/// 탐지 대기 화면 (탐지 시작 전)
+class DetectionIdleView extends StatelessWidget {
+  final VoidCallback onStart;
+
+  const DetectionIdleView({super.key, required this.onStart});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.expand(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Spacer(),
+            DetectionButton(isDetecting: false, onTap: onStart, size: 271),
+            const SizedBox(height: 65),
+            Semantics(
+              label: '카메라를 가슴 앞에 착용해주세요. 실시간으로 위험 요소를 찾아 안내해 드립니다.',
+              excludeSemantics: true,
+              child: SizedBox(
+                width: double.infinity,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      '카메라를 가슴 앞에 착용해주세요.',
+                      style: AppTextStyles.bodyRegular.copyWith(
+                        color: ColorCollection.point,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      '실시간으로 위험 요소를 찾아\n안내해 드립니다.',
+                      style: AppTextStyles.bodyRegular.copyWith(
+                        color: ColorCollection.point,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const Spacer(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/detection/detection_screen.dart
+++ b/lib/features/detection/detection_screen.dart
@@ -31,15 +31,18 @@ class _DetectionScreenState extends State<DetectionScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: const CustomTitleBar(title: '실외 장애물 탐지'),
-      body: SafeArea(
-        child: _isDetecting
-            ? DetectionActiveView(
-                onStop: _stopDetection,
-                detectedCount: _detectedCount,
-              )
-            : DetectionIdleView(onStart: _startDetection),
+    return PopScope(
+      canPop: !_isDetecting,
+      child: Scaffold(
+        appBar: const CustomTitleBar(title: '실외 장애물 탐지'),
+        body: SafeArea(
+          child: _isDetecting
+              ? DetectionActiveView(
+                  onStop: _stopDetection,
+                  detectedCount: _detectedCount,
+                )
+              : DetectionIdleView(onStart: _startDetection),
+        ),
       ),
     );
   }

--- a/lib/features/detection/detection_screen.dart
+++ b/lib/features/detection/detection_screen.dart
@@ -1,30 +1,45 @@
 import 'package:flutter/material.dart';
-import 'package:safepath/common/theme/text_styles.dart';
-import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/widgets/title_bar_widget.dart';
+import 'package:safepath/features/detection/detection_active_view.dart';
+import 'package:safepath/features/detection/detection_idle_view.dart';
 
-class DetectionScreen extends StatelessWidget {
+class DetectionScreen extends StatefulWidget {
   const DetectionScreen({super.key});
+
+  @override
+  State<DetectionScreen> createState() => _DetectionScreenState();
+}
+
+class _DetectionScreenState extends State<DetectionScreen> {
+  bool _isDetecting = false;
+
+  // TODO: 실제 탐지 로직 연결 시 여기서 카메라/모델 제어
+  int _detectedCount = 0;
+
+  void _startDetection() {
+    setState(() {
+      _isDetecting = true;
+      _detectedCount = 0;
+    });
+  }
+
+  void _stopDetection() {
+    setState(() {
+      _isDetecting = false;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomTitleBar(title: '실외 장애물 탐지'),
+      appBar: const CustomTitleBar(title: '실외 장애물 탐지'),
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '실외 장애물 탐지',
-                style: AppTextStyles.title2.copyWith(
-                  color: ColorCollection.point,
-                ),
-              ),
-            ],
-          ),
-        ),
+        child: _isDetecting
+            ? DetectionActiveView(
+                onStop: _stopDetection,
+                detectedCount: _detectedCount,
+              )
+            : DetectionIdleView(onStart: _startDetection),
       ),
     );
   }

--- a/lib/features/detection/obstacle_card_widget.dart
+++ b/lib/features/detection/obstacle_card_widget.dart
@@ -1,0 +1,309 @@
+import 'package:flutter/material.dart';
+
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+
+/// 장애물과의 거리 단계
+enum ObstacleProximity { near, mid, far }
+
+/// 감지된 장애물 카드 위젯
+///
+/// 사용 예시:
+/// ObstacleCard(
+///   name: '가로수',
+///   distance: '멂',
+///   position: '오른쪽',
+///   vibration: '약한 진동 (1회)',
+///   proximity: ObstacleProximity.far,
+/// )
+///
+/// 추후 AI 전달 값 보고 distance, position 등 그룹화하기
+///
+class ObstacleCard extends StatelessWidget {
+  final String name;
+  final String distance;
+  final String position;
+  final String vibration;
+  final ObstacleProximity proximity;
+
+  const ObstacleCard({
+    super.key,
+    required this.name,
+    required this.distance,
+    required this.position,
+    required this.vibration,
+    required this.proximity,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isNear = proximity == ObstacleProximity.near;
+
+    final semanticsLabel =
+        '$name. ${_proximityLabel(proximity)}. '
+        '거리 : $distance. 위치 : $position. 진동 : $vibration.'
+        '${isNear ? ' 즉시 주의 필요 - 매우 가까운 장애물.' : ''}';
+
+    return Semantics(
+      label: semanticsLabel,
+      excludeSemantics: true,
+      child: switch (proximity) {
+        ObstacleProximity.near => _NearCard(this),
+        ObstacleProximity.mid => _MidCard(this),
+        ObstacleProximity.far => _FarCard(this),
+      },
+    );
+  }
+
+  static String _proximityLabel(ObstacleProximity p) => switch (p) {
+    ObstacleProximity.near => 'Near',
+    ObstacleProximity.mid => 'Mid',
+    ObstacleProximity.far => 'Far',
+  };
+}
+
+// ─── Near 카드 (실선 두꺼운 테두리) ───────────────────────────────────────────
+
+class _NearCard extends StatelessWidget {
+  final ObstacleCard data;
+  const _NearCard(this.data);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: ColorCollection.point.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: ColorCollection.main, width: 3),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _CardHeader(name: data.name, proximity: data.proximity),
+            const SizedBox(height: 12),
+            _InfoRow(icon: Icons.adjust, label: '거리', value: data.distance),
+            const SizedBox(height: 8),
+            _InfoRow(icon: Icons.explore, label: '위치', value: data.position),
+            const SizedBox(height: 8),
+            _InfoRow(icon: Icons.vibration, label: '진동', value: data.vibration),
+            const SizedBox(height: 12),
+            const Divider(color: ColorCollection.main, thickness: 1),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Icon(
+                  Icons.notifications_active,
+                  color: ColorCollection.main,
+                  size: 18,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '즉시 주의 필요 - 매우 가까운 장애물',
+                  style: AppTextStyles.labelBold.copyWith(
+                    color: ColorCollection.main,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Mid 카드 (실선 두께 2) ───────────────────────────────────────────────────
+
+class _MidCard extends StatelessWidget {
+  final ObstacleCard data;
+  const _MidCard(this.data);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: ColorCollection.point.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: ColorCollection.point.withValues(alpha: 0.5),
+          width: 2,
+        ),
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _CardHeader(name: data.name, proximity: data.proximity),
+          const SizedBox(height: 12),
+          _InfoRow(icon: Icons.adjust, label: '거리', value: data.distance),
+          const SizedBox(height: 8),
+          _InfoRow(icon: Icons.explore, label: '위치', value: data.position),
+          const SizedBox(height: 8),
+          _InfoRow(icon: Icons.vibration, label: '진동', value: data.vibration),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Far 카드 (점선 테두리) ───────────────────────────────────────────────────
+
+class _FarCard extends StatelessWidget {
+  final ObstacleCard data;
+  const _FarCard(this.data);
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _DashedBorderPainter(
+        color: ColorCollection.point.withValues(alpha: 0.5),
+        borderRadius: 10,
+      ),
+      child: Container(
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: ColorCollection.point.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _CardHeader(name: data.name, proximity: data.proximity),
+            const SizedBox(height: 12),
+            _InfoRow(icon: Icons.adjust, label: '거리', value: data.distance),
+            const SizedBox(height: 8),
+            _InfoRow(icon: Icons.explore, label: '위치', value: data.position),
+            const SizedBox(height: 8),
+            _InfoRow(icon: Icons.vibration, label: '진동', value: data.vibration),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─── 공통 서브 위젯 ───────────────────────────────────────────────────────────
+
+class _CardHeader extends StatelessWidget {
+  final String name;
+  final ObstacleProximity proximity;
+
+  const _CardHeader({required this.name, required this.proximity});
+
+  @override
+  Widget build(BuildContext context) {
+    final isNear = proximity == ObstacleProximity.near;
+    final icon = isNear ? Icons.notifications_active : Icons.info_outline;
+    final label = ObstacleCard._proximityLabel(proximity);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          name,
+          style: AppTextStyles.bodyBold.copyWith(color: ColorCollection.point),
+        ),
+        Row(
+          children: [
+            Icon(icon, color: ColorCollection.main, size: 18),
+            const SizedBox(width: 4),
+            Text(
+              label,
+              style: AppTextStyles.bodyBold.copyWith(
+                color: ColorCollection.main,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, color: ColorCollection.main, size: 18),
+        const SizedBox(width: 8),
+        Text(
+          '$label : $value',
+          style: AppTextStyles.bodyRegular.copyWith(
+            color: ColorCollection.point,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─── 점선 테두리 Painter ──────────────────────────────────────────────────────
+
+class _DashedBorderPainter extends CustomPainter {
+  final Color color;
+  final double borderRadius;
+
+  const _DashedBorderPainter({required this.color, required this.borderRadius});
+
+  static const double _strokeWidth = 1.5;
+  static const double _dashWidth = 6;
+  static const double _dashSpace = 4;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = _strokeWidth
+      ..style = PaintingStyle.stroke;
+
+    final path = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(
+            _strokeWidth / 2,
+            _strokeWidth / 2,
+            size.width - _strokeWidth,
+            size.height - _strokeWidth,
+          ),
+          Radius.circular(borderRadius),
+        ),
+      );
+
+    canvas.drawPath(_dashPath(path), paint);
+  }
+
+  Path _dashPath(Path source) {
+    final result = Path();
+    for (final metric in source.computeMetrics()) {
+      double distance = 0;
+      while (distance < metric.length) {
+        result.addPath(
+          metric.extractPath(distance, distance + _dashWidth),
+          Offset.zero,
+        );
+        distance += _dashWidth + _dashSpace;
+      }
+    }
+    return result;
+  }
+
+  @override
+  bool shouldRepaint(_DashedBorderPainter old) =>
+      old.color != color || old.borderRadius != borderRadius;
+}

--- a/lib/features/detection/obstacle_card_widget.dart
+++ b/lib/features/detection/obstacle_card_widget.dart
@@ -73,7 +73,7 @@ class _NearCard extends StatelessWidget {
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
-        color: ColorCollection.point.withValues(alpha: 0.1),
+        color: ColorCollection.main.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(10),
         border: Border.all(color: ColorCollection.main, width: 3),
       ),
@@ -97,7 +97,7 @@ class _NearCard extends StatelessWidget {
                 const Icon(
                   Icons.notifications_active,
                   color: ColorCollection.main,
-                  size: 18,
+                  size: 20,
                 ),
                 const SizedBox(width: 8),
                 Text(
@@ -128,10 +128,7 @@ class _MidCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: ColorCollection.point.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(10),
-        border: Border.all(
-          color: ColorCollection.point.withValues(alpha: 0.5),
-          width: 2,
-        ),
+        border: Border.all(color: ColorCollection.main, width: 2),
       ),
       padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
       child: Column(
@@ -240,7 +237,7 @@ class _InfoRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Icon(icon, color: ColorCollection.main, size: 18),
+        Icon(icon, color: ColorCollection.main, size: 20),
         const SizedBox(width: 8),
         Text(
           '$label : $value',


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#8 

## 📄 작업 내용 요약
장애물 탐지 페이지 UI 구현
- 장애물 탐지 알림 위젯 구현
- 장애물 탐지 시작/중지 위젯 구현
- 장애물 탐지 전/중 페이지 UI 구현

## 🗨️ 리뷰 요구 사항
탐지 알림 카드 Mid 테두리를 Near이랑 같은 주황으로 하니까 별로 티가 안 나서 흰색으로 했는데 확인해주세요