### PR TITLE
[FIX] 길찾기 화면 편집 버튼을 더보기 버튼으로 수정

### DIFF
--- a/lib/features/navigation/more_button.dart
+++ b/lib/features/navigation/more_button.dart
@@ -3,8 +3,8 @@ import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/routes/app_router.dart';
 
-class EditButton extends StatelessWidget {
-  const EditButton({super.key});
+class MoreButton extends StatelessWidget {
+  const MoreButton({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -26,10 +26,14 @@ class EditButton extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                Icon(Icons.edit, size: 18, color: ColorCollection.point),
+                Icon(
+                  Icons.more_horiz_rounded,
+                  size: 25,
+                  color: ColorCollection.point,
+                ),
                 const SizedBox(width: 5),
                 Text(
-                  '편집',
+                  '더보기',
                   style: AppTextStyles.labelRegular.copyWith(
                     color: ColorCollection.point,
                   ),

--- a/lib/features/navigation/navigation_screen.dart
+++ b/lib/features/navigation/navigation_screen.dart
@@ -6,7 +6,7 @@ import 'package:safepath/common/widgets/action_button_widget.dart';
 import 'package:safepath/common/widgets/text_input_bar.dart';
 import 'package:safepath/common/widgets/title_bar_widget.dart';
 import 'package:safepath/features/navigation/current_place_widget.dart';
-import 'package:safepath/features/navigation/edit_button.dart';
+import 'package:safepath/features/navigation/more_button.dart';
 import 'package:safepath/features/navigation/saved_place_widget.dart';
 import 'package:safepath/routes/app_router.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
@@ -121,7 +121,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
                         fontSize: 20,
                       ),
                     ),
-                    EditButton(),
+                    MoreButton(),
                   ],
                 ),
                 const SizedBox(height: 25),


### PR DESCRIPTION
## 📎 Issue 번호
#5 

## 📄 작업 내용 요약
- 길찾기 화면의 기존의 편집 버튼을 더보기 버튼으로 수정(UI만 변경, 기능 변경 X)
