### PR TITLE
[FIX] 시스템 뒤로가기 동작 수정(홈 탭 이동 처리)

### DIFF
--- a/lib/layout/layout.dart
+++ b/lib/layout/layout.dart
@@ -45,8 +45,16 @@ class _MainLayoutState extends State<MainLayout> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: IndexedStack(index: _currentIndex, children: _pages),
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (_currentIndex != 0) {
+          setState(() => _currentIndex = 0);
+        }
+        // 홈 탭에서는 뒤로가기 무시 (로그인으로 안 돌아감)
+      },
+      child: Scaffold(
+        body: IndexedStack(index: _currentIndex, children: _pages),
       bottomNavigationBar: Container(
         decoration: const BoxDecoration(
           border: Border(
@@ -81,6 +89,8 @@ class _MainLayoutState extends State<MainLayout> {
           ],
         ),
       ),
+      ),
     );
   }
 }
+


### PR DESCRIPTION
## 📎 Issue 번호
<!-- closed #번호 -->
#8 

## 📄 작업 내용 요약
- MainLayout에 PopScope 추가하여 시스템 뒤로가기 동작 제어
- 다른 탭에서 뒤로가기 시 홈 탭으로 이동하도록 수정
- 홈 탭에서 뒤로가기 시 로그인 화면으로 이동하지 않도록 처리
- 로그인 이후 MainLayout 사용 시 라우트 스택 문제로 로그인 화면으로 돌아가던 UX 개선