### PR TITLE
[FEAT] 길찾기 화면 - 현재 위치 불러오기 및 목적지 위젯 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application
         android:label="safepath"

--- a/lib/features/navigation/navigation_screen.dart
+++ b/lib/features/navigation/navigation_screen.dart
@@ -8,8 +8,11 @@ import 'package:safepath/common/widgets/title_bar_widget.dart';
 import 'package:safepath/features/navigation/current_place_widget.dart';
 import 'package:safepath/features/navigation/more_button.dart';
 import 'package:safepath/features/navigation/saved_place_widget.dart';
+import 'package:safepath/data/saved_place_dummy.dart';
 import 'package:safepath/routes/app_router.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
+import 'package:geolocator/geolocator.dart';
+import 'package:geocoding/geocoding.dart';
 
 class NavigationScreen extends StatefulWidget {
   const NavigationScreen({super.key});
@@ -25,6 +28,10 @@ class _NavigationScreenState extends State<NavigationScreen> {
   /// 텍스트 입력 여부 확인
   bool get _hasDestination => destinationController.text.trim().isNotEmpty;
 
+  /// 위치 변수
+  String currentLocation = "현재 위치 불러오는 중...";
+  String selectedLocation = "목적지를 선택해 주세요.";
+
   @override
   void initState() {
     super.initState();
@@ -32,6 +39,8 @@ class _NavigationScreenState extends State<NavigationScreen> {
     destinationController.addListener(() {
       setState(() {});
     });
+
+    loadLocation();
   }
 
   /// destinationController의 listener 해제
@@ -74,6 +83,73 @@ class _NavigationScreenState extends State<NavigationScreen> {
     });
   }
 
+  /// 현재 위치 가져오기
+  Future<Position> getCurrentLocation() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    // 위치 서비스 활성화 확인
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      throw Exception('위치 서비스가 꺼져 있습니다.');
+    }
+
+    // 권한 확인
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+
+    if (permission == LocationPermission.denied) {
+      throw Exception('위치 권한이 거부되었습니다.');
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      throw Exception('위치 권한이 영구적으로 거부되었습니다.');
+    }
+
+    // 현재 위치 가져오기
+    return await Geolocator.getCurrentPosition(
+      desiredAccuracy: LocationAccuracy.high,
+    );
+  }
+
+  void loadLocation() async {
+    try {
+      final position = await getCurrentLocation();
+
+      List<Placemark> placemarks = await placemarkFromCoordinates(
+        position.latitude,
+        position.longitude,
+        localeIdentifier: "ko_KR",
+      );
+
+      Placemark place = placemarks.first;
+
+      // administrativeArea : 서울특별시
+      // subAdministrativeArea : 성북구
+      // thoroughfare : 정릉로
+      // subThoroughfare : 77
+
+      String address = [
+        place.administrativeArea,
+        place.subAdministrativeArea,
+        place.locality,
+        place.subLocality,
+        place.thoroughfare,
+        place.subThoroughfare,
+      ].where((e) => e != null && e!.isNotEmpty).join(' ');
+
+      setState(() {
+        currentLocation = address;
+      });
+    } catch (e) {
+      setState(() {
+        currentLocation = "위치 불러오기 실패";
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -97,10 +173,9 @@ class _NavigationScreenState extends State<NavigationScreen> {
                   },
                 ),
                 const SizedBox(height: 16),
-                CurrentPlaceWidget(
-                  label: '현재 위치',
-                  location: '서울특별시 성북구 정릉로 77',
-                ),
+                CurrentPlaceWidget(label: '현재 위치', location: currentLocation),
+                const SizedBox(height: 16),
+                CurrentPlaceWidget(label: '목적지 위치', location: selectedLocation),
                 const SizedBox(height: 16),
                 ActionButton(
                   label: '안내 시작',
@@ -132,6 +207,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
                           setState(() {
                             destinationController.text =
                                 (place as dynamic).label;
+                            selectedLocation = (place as dynamic).location;
                           });
                         }
                       },
@@ -139,17 +215,22 @@ class _NavigationScreenState extends State<NavigationScreen> {
                   ],
                 ),
                 const SizedBox(height: 25),
-                SavedPlaceWidget(
-                  label: '집',
-                  location: '서울특별시 성북구 솔샘로8길',
-                  category: PlaceCategory.home,
-                  onTap: () {
-                    setState(() {
-                      destinationController.text = '집';
-                    });
-                  },
-                ),
-                const SizedBox(height: 25),
+                ...savedPlaces.take(2).map((place) {
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 25),
+                    child: SavedPlaceWidget(
+                      label: place.label,
+                      location: place.location,
+                      category: place.category,
+                      onTap: () {
+                        setState(() {
+                          destinationController.text = place.label;
+                          selectedLocation = place.location;
+                        });
+                      },
+                    ),
+                  );
+                }).toList(),
 
                 /// 최근 장소 섹션
                 Text(
@@ -169,6 +250,7 @@ class _NavigationScreenState extends State<NavigationScreen> {
                     });
                   },
                 ),
+                const SizedBox(height: 25),
               ],
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -57,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,6 +96,86 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  geocoding:
+    dependency: "direct main"
+    description:
+      name: geocoding
+      sha256: "790eea732b22a08dd36fc3761bcd29040461ac20ece4d165264a6c0b5338f115"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  geocoding_android:
+    dependency: transitive
+    description:
+      name: geocoding_android
+      sha256: "1b13eca79b11c497c434678fed109c2be020b158cec7512c848c102bc7232603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  geocoding_ios:
+    dependency: transitive
+    description:
+      name: geocoding_ios
+      sha256: "8a39bfb650af55209c42e564036a550b32d029e0733af01dc66c5afea50388d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  geocoding_platform_interface:
+    dependency: transitive
+    description:
+      name: geocoding_platform_interface
+      sha256: "8c2c8226e5c276594c2e18bfe88b19110ed770aeb7c1ab50ede570be8b92229b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: "6cb9fb6e5928b58b9a84bdf85012d757fd07aab8215c5205337021c4999bad27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.1.0"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: fcb1760a50d7500deca37c9a666785c047139b5f9ee15aa5469fae7dbbe3170d
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.2"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.13"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.6"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: "49d8f846ebeb5e2b6641fe477a7e97e5dd73f03cbfef3fd5c42177b7300fb0ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   json_annotation:
     dependency: transitive
     description:
@@ -245,6 +341,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   speech_to_text: ^7.3.0
+  geolocator: ^11.0.0
+  geocoding: ^2.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📎 Issue 번호
#5 


## 📄 작업 내용 요약
- geolocator, geocoding(임시) 라이브러리 추가
   geocoding의 경우 SK Open API 사용 전 위도 경도를 도로명 주소로 변환하여 UI로 표시하기 위함
- 위치 공유 권한 설정
- 현재 위치 불러오기
- 목적지 선택시 목적지의 주소를 보여주는 위젯 추가
<img width=45% alt="locationpermissionscreen" src="https://github.com/user-attachments/assets/edf009f5-6477-471c-bd49-2712b0defa20" />
<img width=45% alt="locationscreen1" src="https://github.com/user-attachments/assets/876536f9-e51d-4555-aa9e-0c3bfb163a2f" />
