### PR TITLE
[FEAT] 길찾기 안내 중 페이지 구현

### DIFF
--- a/lib/features/navigation/navigation_ing_screen.dart
+++ b/lib/features/navigation/navigation_ing_screen.dart
@@ -3,7 +3,10 @@ import 'package:safepath/common/theme/color_collection.dart';
 import 'package:safepath/common/theme/text_styles.dart';
 import 'package:safepath/common/widgets/action_button_widget.dart';
 import 'package:safepath/common/widgets/title_bar_widget.dart';
+import 'package:safepath/features/navigation/navigation_step_card.dart';
+import 'package:safepath/features/navigation/navigation_voiceguide_card.dart';
 import 'package:safepath/routes/app_router.dart';
+import 'package:safepath/features/navigation/navigation_overview_card.dart';
 
 class NavigationIngScreen extends StatefulWidget {
   const NavigationIngScreen({super.key});
@@ -20,27 +23,47 @@ class _NavigationIngScreenState extends State<NavigationIngScreen> {
       child: Scaffold(
         appBar: CustomTitleBar(title: '길찾기'),
         body: SafeArea(
+          bottom: false,
           child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '길찾기 중',
-                    style: AppTextStyles.labelRegular.copyWith(
-                      color: ColorCollection.point,
+            padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        NavigationOverviewCard(
+                          distance: 850,
+                          time: 12,
+                          status: RouteStatus.safe,
+                        ),
+                        const SizedBox(height: 20),
+                        NavigationStepCard(
+                          direction: DirectionType.straight,
+                          instruction: '100m 앞에서 우회전하세요.',
+                          distance: 100,
+                        ),
+                        const SizedBox(height: 20),
+                        NavigationVoiceGuideCard(
+                          voiceGuide: '50미터 앞 오른쪽에 킥보드가 감지되었습니다.',
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(height: 30),
-                  ActionButton(
-                    label: '안내 중지',
-                    icon: Icons.stop_circle_outlined,
-                    backgroundColor: ColorCollection.red,
-                    onTap: () => Navigator.pop(context),
+                ),
+                SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 16, bottom: 24),
+                    child: ActionButton(
+                      label: '안내 중지',
+                      icon: Icons.stop_circle_outlined,
+                      backgroundColor: ColorCollection.red,
+                      onTap: () => Navigator.pop(context),
+                    ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/features/navigation/navigation_overview_card.dart
+++ b/lib/features/navigation/navigation_overview_card.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+
+enum RouteStatus { safe, warning, danger }
+
+class NavigationOverviewCard extends StatelessWidget {
+  final int distance; // 남은 거리
+  final int time; // 남은 소요 시간
+  final RouteStatus status;
+
+  const NavigationOverviewCard({
+    super.key,
+    required this.distance,
+    required this.time,
+    required this.status,
+  });
+
+  String _getStatusText(RouteStatus status) {
+    switch (status) {
+      case RouteStatus.safe:
+        return '안전';
+      case RouteStatus.warning:
+        return '주의';
+      case RouteStatus.danger:
+        return '위험';
+    }
+  }
+
+  Color _getStatusColor(RouteStatus status) {
+    switch (status) {
+      case RouteStatus.safe:
+        return ColorCollection.green;
+      case RouteStatus.warning:
+        return ColorCollection.yellow;
+      case RouteStatus.danger:
+        return ColorCollection.red;
+    }
+  }
+
+  String _formatDistance(int distance) {
+    if (distance >= 1000) {
+      return '${(distance / 1000).toStringAsFixed(1)}km';
+    }
+    return '${distance}m';
+  }
+
+  String _formatTime(int time) {
+    if (time >= 60) {
+      final hour = time ~/ 60;
+      final minute = time % 60;
+
+      if (minute == 0) {
+        return '${hour}시간';
+      }
+      return '${hour}시간 ${minute}분';
+    }
+    return '${time}분';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: ColorCollection.point, width: 3),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              _formatDistance(distance),
+              style: AppTextStyles.title1.copyWith(
+                color: ColorCollection.point,
+                fontSize: 40,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '남은 거리',
+              style: AppTextStyles.labelBold.copyWith(
+                color: ColorCollection.point,
+              ),
+            ),
+            const SizedBox(height: 15),
+            Divider(color: ColorCollection.point, thickness: 2),
+            const SizedBox(height: 15),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Column(
+                  children: [
+                    Text(
+                      _formatTime(time),
+                      style: AppTextStyles.title2.copyWith(
+                        color: ColorCollection.point,
+                        fontSize: 20,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '남은 시간',
+                      style: AppTextStyles.labelBold.copyWith(
+                        color: ColorCollection.point,
+                      ),
+                    ),
+                  ],
+                ),
+                Column(
+                  children: [
+                    Text(
+                      _getStatusText(status),
+                      style: AppTextStyles.title2.copyWith(
+                        color: _getStatusColor(status),
+                        fontSize: 20,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '경로 상태',
+                      style: AppTextStyles.labelBold.copyWith(
+                        color: ColorCollection.point,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/navigation/navigation_step_card.dart
+++ b/lib/features/navigation/navigation_step_card.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+
+enum DirectionType {
+  straight, // 직진
+  left, // 좌회전
+  right, // 우회전
+  crosswalk, // 횡단보도
+}
+
+class NavigationStepCard extends StatelessWidget {
+  final DirectionType direction;
+  final String instruction;
+  final int distance;
+
+  const NavigationStepCard({
+    super.key,
+    required this.direction,
+    required this.instruction,
+    required this.distance,
+  });
+
+  IconData _getDirectionIcon(DirectionType direction) {
+    switch (direction) {
+      case DirectionType.straight:
+        return Icons.arrow_upward;
+      case DirectionType.left:
+        return Icons.turn_left;
+      case DirectionType.right:
+        return Icons.turn_right;
+      case DirectionType.crosswalk:
+        return Icons.directions_walk;
+    }
+  }
+
+  String _getDirectionLabel(DirectionType direction) {
+    switch (direction) {
+      case DirectionType.straight:
+        return '직진';
+      case DirectionType.left:
+        return '좌회전';
+      case DirectionType.right:
+        return '우회전';
+      case DirectionType.crosswalk:
+        return '횡단보도';
+    }
+  }
+
+  String _formatDistance(int distance) {
+    if (distance >= 1000) {
+      return '${(distance / 1000).toStringAsFixed(1)}km';
+    }
+    return '${distance}m';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: ColorCollection.point.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: ColorCollection.main, width: 2),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 50,
+                  height: 50,
+                  decoration: BoxDecoration(
+                    color: ColorCollection.main,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(
+                    _getDirectionIcon(direction),
+                    color: ColorCollection.point,
+                    size: 45,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '${_formatDistance(distance)} ${_getDirectionLabel(direction)}',
+                        style: AppTextStyles.title2.copyWith(
+                          color: ColorCollection.point,
+                          fontSize: 20,
+                        ),
+                      ),
+                      const SizedBox(height: 5),
+                      Text(
+                        '다음 안내까지',
+                        style: AppTextStyles.labelRegular.copyWith(
+                          color: ColorCollection.point,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: 20),
+
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
+              decoration: BoxDecoration(
+                color: ColorCollection.main.withOpacity(0.5),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(
+                    Icons.volume_up_rounded,
+                    color: ColorCollection.point,
+                    size: 35,
+                  ),
+                  const SizedBox(width: 7),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        instruction,
+                        style: AppTextStyles.labelBold.copyWith(
+                          color: ColorCollection.point,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/navigation/navigation_voiceguide_card.dart
+++ b/lib/features/navigation/navigation_voiceguide_card.dart
@@ -1,0 +1,59 @@
+import 'package:dotted_border/dotted_border.dart';
+import 'package:flutter/material.dart';
+import 'package:safepath/common/theme/color_collection.dart';
+import 'package:safepath/common/theme/text_styles.dart';
+
+class NavigationVoiceGuideCard extends StatelessWidget {
+  final String voiceGuide;
+
+  const NavigationVoiceGuideCard({super.key, required this.voiceGuide});
+
+  @override
+  Widget build(BuildContext context) {
+    return DottedBorder(
+      borderType: BorderType.RRect,
+      radius: const Radius.circular(10),
+      dashPattern: const [4, 4], // 점 길이, 간격
+      color: ColorCollection.yellow,
+      strokeWidth: 2,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: ColorCollection.yellow.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Icon(
+                  Icons.warning_amber_rounded,
+                  color: ColorCollection.yellow,
+                  size: 40,
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  '주의',
+                  style: AppTextStyles.title2.copyWith(
+                    color: ColorCollection.point,
+                    fontSize: 20,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              voiceGuide,
+              style: AppTextStyles.labelBold.copyWith(
+                color: ColorCollection.point,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dotted_border:
+    dependency: "direct main"
+    description:
+      name: dotted_border
+      sha256: "108837e11848ca776c53b30bc870086f84b62ed6e01c503ed976e8f8c7df9c04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -304,6 +312,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   pedantic:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   speech_to_text: ^7.3.0
   geolocator: ^11.0.0
   geocoding: ^2.1.1
+  dotted_border: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📎 Issue 번호
#5 

## 📄 작업 내용 요약
- 길찾기 안내 중 페이지 구현
- 길찾기 안내 중 페이지에 사용되는 카드 위젯들 구현
- 점선 테두리의 컨테이너 구현을 위한 라이브러리 추가

<img width="1080" height="2340" alt="Screenshot_20260330_190457" src="https://github.com/user-attachments/assets/9602a0e9-ef4e-470f-aa56-f4bc9b70ca9d" />
